### PR TITLE
Adapt Makefile to be more generic.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,13 @@
-obj-m:=vmlaunch_simple.o
+KERNEL_TREE_PATH?=/lib/modules/$(shell uname -r)/build
+
+obj-m := vmlaunch_simple.o
+
+all: vmlaunch_simple.ko
+
+vmlaunch_simple.ko: vmlaunch_simple.c
+	make -C $(KERNEL_TREE_PATH) M=$(PWD) modules
+
+clean:
+	make -C $(KERNEL_TREE_PATH) M=$(PWD) clean
+
+.PHONY: all clean

--- a/cmd
+++ b/cmd
@@ -1,1 +1,1 @@
-sudo make -C /home/vmohan/k3/linux-2.6/  M=`pwd` modules
+make

--- a/cmdclean
+++ b/cmdclean
@@ -1,1 +1,1 @@
-sudo make -C /home/vmohan/k3/linux-2.6/  M=`pwd` clean
+make clean


### PR DESCRIPTION
This allows the project to be made with a simple `make` command, it defaults to
the default system modules folder at `/lib/modules/$(uname -r)/build` but this
can be overridden by setting the `KERNEL_TREE_PATH` Makefile variable.

I also updated `cmd` and `cmdclean` to simply invoke `make` and `make clean`
respectively, there didn't seem to be any need to run these commands elevated.
